### PR TITLE
Kidroca patch 2

### DIFF
--- a/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
+++ b/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
@@ -130,7 +130,7 @@ exports.tests = [
     
     {name:"#logo height", points: 1, func:function(){
         return $("#logo").outerHeight();
-    }, expected: 65, compare: "equalDiff", compareParam: 0},
+    }, expected: 65, compare: "equalDiff", compareParam: 2},
     
     {name:".separator height", points: 2, func:function(){
         return parseInt($(".separator").eq(0).css("height"));
@@ -171,7 +171,7 @@ exports.tests = [
     }, expected: 970, compare: "equalDiff", compareParam: 5},
     
     {name:"Main horizontal line width", points: 2, func:function(){
-        return parseInt($("#main hr").css("width"));
+        return parseInt($("#main hr")..outerWidth());
     }, expected: 968, compare: "equalDiff", compareParam: 5},
     
     

--- a/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
+++ b/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
@@ -156,7 +156,7 @@ exports.tests = [
     // Widths (max 10)
     {name:"#logo width", points: 2, func:function(){
         return $("#logo").outerWidth();
-    }, expected: 175, compare: "equalDiff", compareParam: 0},
+    }, expected: 175, compare: "equalDiff", compareParam: 5},
     
     {name:".separator width", points: 2, func:function(){
         return parseInt($(".separator").outerWidth());


### PR DESCRIPTION
# logo white space , main hr width …

логото е картинка която има бяло пространство в краищата си , което на бял фон не се вижда или може да се изреже като се сложи в по тесен контеинер.

main hr - не се взема в предвид дебелината на border т.е. самата черта ако се направи с border: 4px solid black ,което също е валидно решение, нейната дебелина е само 960px .
# language и #footerMenu ми паснаха със font-size: 13px но това сигурно не може да се промени.

Извинявам се за повторенията но още не ми е ясен много github
