### PR TITLE
#logo height test fix to include margins

### DIFF
--- a/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
+++ b/examples/telerik-academy-2015-css-exam-1-task-2/tests.js
@@ -133,8 +133,8 @@ exports.tests = [
     }, expected: true, compare: "equal", compareParam: null},
     
     {name:"#logo height", points: 1, func:function(){
-        return $("#logo").outerHeight();
-    }, expected: 65, compare: "equalDiff", compareParam: 0},
+        return $("#logo").outerHeight() == 65 || $("#logo").outerHeight(true) == 65;
+    }, expected: true, compare: "equal", compareParam: null},
     
     {name:".separator height", points: 2, func:function(){
         return parseInt($(".separator").eq(0).css("height"));


### PR DESCRIPTION
Apperantly this way the solution can also be pixel-perfect because the logo image is set with background-image and thus the image does not change it's proportions. Although I agree that if the image was different the results would be wrong because the image would be cropped from the bottom.
